### PR TITLE
Detect out of order control batches + print abort command

### DIFF
--- a/src/main/java/com/github/tombentley/klog/segment/reader/SegmentDumpReader.java
+++ b/src/main/java/com/github/tombentley/klog/segment/reader/SegmentDumpReader.java
@@ -399,7 +399,7 @@ public class SegmentDumpReader {
         Arrays.stream(args).map(File::new).map(dumpFile ->
                 segmentDumpReader.readSegment(dumpFile).batches().collect(TransactionalInfoCollector.collector())).forEach(x -> {
             System.out.println("First batch: " + x.firstBatch());
-            x.emptyTransactions().forEach(txn -> System.out.println("Empty txn: " + txn));
+            x.emptyTransactions().values().forEach(txn -> System.out.println("Empty txn: " + txn));
             System.out.println("Last batch: " + x.lastBatch());
             x.openTransactions().forEach((sess, txn) -> System.out.println("Open transaction: " + sess + "->" + txn));
             System.out.println("#committed: " + x.numTransactionalCommit());

--- a/src/main/java/com/github/tombentley/klog/segment/reader/TransactionalInfo.java
+++ b/src/main/java/com/github/tombentley/klog/segment/reader/TransactionalInfo.java
@@ -17,7 +17,6 @@
 package com.github.tombentley.klog.segment.reader;
 
 import java.util.IntSummaryStatistics;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -28,7 +27,7 @@ public final class TransactionalInfo {
     private final Map<ProducerSession, FirstBatchInTxn> openTransactions;
     private final Batch firstBatch;
     private final Batch lastBatch;
-    private final List<EmptyTransaction> emptyTransactions;
+    private final Map<ProducerSession, EmptyTransaction> emptyTransactions;
     private final long numTransactionalCommit;
     private final long numTransactionalAbort;
     private final IntSummaryStatistics txnSizeStats;
@@ -37,7 +36,7 @@ public final class TransactionalInfo {
     public TransactionalInfo(Map<ProducerSession, FirstBatchInTxn> openTransactions,
                              Batch firstBatch,
                              Batch lastBatch,
-                             List<EmptyTransaction> emptyTransactions,
+                             Map<ProducerSession, EmptyTransaction> emptyTransactions,
                              long numTransactionalCommit, long numTransactionalAbort,
                              IntSummaryStatistics txnSizeStats,
                              IntSummaryStatistics txnDurationStats) {
@@ -63,7 +62,7 @@ public final class TransactionalInfo {
         return lastBatch;
     }
 
-    public List<EmptyTransaction> emptyTransactions() {
+    public Map<ProducerSession, EmptyTransaction> emptyTransactions() {
         return emptyTransactions;
     }
 

--- a/src/main/java/com/github/tombentley/klog/segment/reader/TransactionalInfoCollector.java
+++ b/src/main/java/com/github/tombentley/klog/segment/reader/TransactionalInfoCollector.java
@@ -37,7 +37,7 @@ public class TransactionalInfoCollector {
     private Batch currentBatch;
     private final Map<ProducerSession, FirstBatchInTxn> openTransactions = new HashMap<>();
     private Batch firstBatch;
-    private final List<EmptyTransaction> emptyTransactions = new ArrayList<>();
+    private final Map<ProducerSession, EmptyTransaction> emptyTransactions = new HashMap<>();
     private final IntSummaryStatistics txnSizeStats = new IntSummaryStatistics();
     private final IntSummaryStatistics txnDurationStats = new IntSummaryStatistics();
     private long numTransactionalCommit = 0;
@@ -88,7 +88,7 @@ public class TransactionalInfoCollector {
                 }
                 var firstBatchInTxn = openTransactions.remove(currentBatch.session());
                 if (firstBatchInTxn == null) {
-                    emptyTransactions.add(new EmptyTransaction(currentBatch, control));
+                    emptyTransactions.put(currentBatch.session(), new EmptyTransaction(currentBatch, control));
                 } else {
                     txnSizeStats.accept(firstBatchInTxn.numDataBatches().get());
                     txnDurationStats.accept((int) (currentBatch.createTime() - firstBatchInTxn.firstBatchInTxn().createTime()));


### PR DESCRIPTION
Example output:
```
open_txn: ProducerSession[producerId=2, producerEpoch=1]->FirstBatchInTxn[firstBatchInTxn=Batch(baseOffset=24, lastOffset=28, count=5, baseSequence=0, lastSequence=4, producerId=2, producerEpoch=1, partitionLeaderEpoch=0, isTransactional=true, isControl=false, position=774, createTime=2022-01-18T14:26:17.309Z, size=146, magic=2, compressCodec='NONE', crc=1212786461, isValid=true), numDataBatches=1]
Found a matching out of order control batch: EmptyTransaction[closingBatch=Batch(baseOffset=23, lastOffset=23, count=1, baseSequence=-1, lastSequence=-1, producerId=2, producerEpoch=1, partitionLeaderEpoch=0, isTransactional=true, isControl=true, position=696, createTime=2022-01-18T14:26:17.335Z, size=78, magic=2, compressCodec='NONE', crc=-423261568, isValid=true), controlMessage=ControlMessage(offset=23, createTime=2022-01-18T14:26:17.335Z, keySize=4, valueSize=6, sequence=-1, headers='', commit=false, coordinatorEpoch=0)]
To forcibly abort this transaction, run: ./kafka-transactions.sh --bootstrap-server <BOOTSTRAP_SERVER> --command-config <CONFIG_FILE> abort --topic <TOPIC> --partition <PARTITION> --producer-id 2 --producer-epoch 2 --coordinator-epoch 0
```